### PR TITLE
feat(docs): add example of disabled and tooltip properties on dropdown links docs

### DIFF
--- a/docs/list/dropdown-links.md
+++ b/docs/list/dropdown-links.md
@@ -6,30 +6,37 @@ Dropdown links appear in a dropdown menu on [list view](list/list.md) for each i
 
 An [Action](features/actions.md) is triggered on click.
 
+You can _disabled_ a dropdown item based on a condition, it will appear but will not be clickable.
+
+By giving a string to the property _tooltip_ a tooltip will appear on hover.
+
 ```js
 dropdownLinks: [
   {
-    label: "Editer collaborateur",
-    permission: "editUsers",
+    label: 'Editer collaborateur',
+    permission: 'editUsers',
     condition: (user: User) => user.isActive,
     action: (user: User) => ({
       type: ActionType.Link,
       link: {
-        path: `${userDefinition.path}/${user.id}/edit`,
-      },
-    }),
+        path: `${userDefinition.path}/${user.id}/edit`
+      }
+    })
   },
   {
-    label: "Effacer collaborateur",
-    permission: "deleteUsers",
+    label: 'Effacer collaborateur',
+    permission: 'deleteUsers',
     withDivision: true,
     action: (user: User) => ({
       type: ActionType.Delete,
       delete: {
         itemToDelete: user,
-        definition: userDefinition,
-      },
+        definition: userDefinition
+      }
     }),
-  },
-];
+    disabled: (user: User) => user.projects.length || user.isActive,
+    tooltip:
+      'Vous ne pouvez pas effacer un collaborateur actif ou ayant des projets.'
+  }
+]
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

This PR is updating the docs 

## Description

Adding examples of disabled and tooltip properties on dropdown links docs


## How can it be tested?

$ cd docs 
$ docsify serve

Check the update on List view > Dropdown links 

## Check list before submitting

- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I updated the documentation if necessary
- [x] This PR is wrote in a clear language and correctly labeled
